### PR TITLE
automatic generic unlock check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+rename.sh

--- a/core.lua
+++ b/core.lua
@@ -57,6 +57,11 @@ C_Timer.NewTicker(1, (function()
 			foundU('PixelMagic')
 			NeP.Protected.PixelMagic()
 		-- Generic
+		elseif not pT.Generic_Check then
+			local Running = NeP.DSL.Get('toggle')(nil, 'mastertoggle')
+			if Running then
+				pcall(RunMacroText, '/run NeP.Protected.Generic_Check = true')
+			end
 		elseif pT.Generic_Check then
 			foundU('Generic Unlocker')
 			pT.Generic()


### PR DESCRIPTION
This is a resubmit of an earlier PR for the same thing.

Basically it's adding an unlock check to the timer but wrapped inside a guard condition to only issue the pcall if the engine is toggled on, in order to avoid the annoying 'clicking' while it checks over and over.

I could not find any other benign way to check for unlock via the other protected API